### PR TITLE
Create almalinux.mirrors.behostings.net.yaml

### DIFF
--- a/almalinux.mirrors.behostings.net.yaml
+++ b/almalinux.mirrors.behostings.net.yaml
@@ -1,0 +1,14 @@
+---
+name: almalinux.mirrors.behostings.net
+address:
+  http: http://almalinux.mirrors.behostings.net/
+  https: https://almalinux.mirrors.behostings.net/
+geolocation:
+  country: BE
+  state_province: Walloon Brabant
+  city: Jodoigne
+update_frequency: 3h
+sponsor: BE HOSTINGS ©2019 The Hosting Group - Diogenius
+sponsor_url: https://www.behostings.com/fr/
+email: basil.m@thgnet.net
+...


### PR DESCRIPTION
---
name: almalinux.mirrors.behostings.net
address:
  http: http://almalinux.mirrors.behostings.net/
  https: https://almalinux.mirrors.behostings.net/
geolocation:
  country: BE
  state_province: Walloon Brabant
  city: Jodoigne
update_frequency: 3h
sponsor: BE HOSTINGS ©2019 The Hosting Group - Diogenius
sponsor_url: https://www.behostings.com/fr/
email: basil.m@thgnet.net
...